### PR TITLE
Adding option to set dt 

### DIFF
--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -227,7 +227,7 @@ def red_noise_block(psd='powerlaw', prior='log-uniform', Tspan=None,
 
 
 def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
-                   prior='log-uniform', Tspan=None, components=30,
+                   prior='log-uniform', Tspan=None, components=30, dm_dt=15,
                    gamma_val=None, coefficients=False):
     """
     Returns DM noise model:
@@ -244,6 +244,8 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
         use overall time span for indivicual pulsar.
     :param components:
         Number of frequencies in sampling of DM-variations.
+    :param dm_dt:
+        Step size for linear_interpolation_basis in units of days.
     :param gamma_val:
         If given, this is the fixed slope of the power-law for
         powerlaw, turnover, or tprocess DM-variations
@@ -308,7 +310,7 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
             log10_p = parameter.Uniform(-4, 1)
             log10_gam_p = parameter.Uniform(-3, 2)
 
-            dm_basis = gpk.linear_interp_basis_dm(dt=15*86400)
+            dm_basis = gpk.linear_interp_basis_dm(dt=dm_dt*86400)
             dm_prior = gpk.periodic_kernel(log10_sigma=log10_sigma,
                                            log10_ell=log10_ell,
                                            log10_gam_p=log10_gam_p,
@@ -322,7 +324,7 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
             log10_p = parameter.Uniform(-4, 1)
             log10_gam_p = parameter.Uniform(-3, 2)
 
-            dm_basis = gpk.get_tf_quantization_matrix(df=200, dt=15*86400,
+            dm_basis = gpk.get_tf_quantization_matrix(df=200, dt=dm_dt*86400,
                                                       dm=True)
             dm_prior = gpk.tf_kernel(log10_sigma=log10_sigma,
                                      log10_ell=log10_ell,
@@ -334,7 +336,7 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
             log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
 
-            dm_basis = gpk.linear_interp_basis_dm(dt=15*86400)
+            dm_basis = gpk.linear_interp_basis_dm(dt=dm_dt*86400)
             dm_prior = gpk.se_dm_kernel(log10_sigma=log10_sigma,
                                         log10_ell=log10_ell)
         elif nondiag_kernel == 'sq_exp_rfband':
@@ -344,7 +346,7 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
             log10_ell2 = parameter.Uniform(2, 7)
             log10_alpha_wgt = parameter.Uniform(-4, 1)
 
-            dm_basis = gpk.get_tf_quantization_matrix(df=200, dt=15*86400,
+            dm_basis = gpk.get_tf_quantization_matrix(df=200, dt=dm_dt*86400,
                                                       dm=True)
             dm_prior = gpk.sf_kernel(log10_sigma=log10_sigma,
                                      log10_ell=log10_ell,
@@ -354,7 +356,7 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
             # DMX-like signal
             log10_sigma = parameter.Uniform(-10, -4)
 
-            dm_basis = gpk.linear_interp_basis_dm(dt=30*86400)
+            dm_basis = gpk.linear_interp_basis_dm(dt=dm_dt*86400)
             dm_prior = gpk.dmx_ridge_prior(log10_sigma=log10_sigma)
 
     dmgp = gp_signals.BasisGP(dm_prior, dm_basis, name='dm_gp',
@@ -368,7 +370,7 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
                           prior='log-uniform',
                           idx=4, include_quadratic=False,
                           Tspan=None, name='chrom', components=30,
-                          coefficients=False):
+                          chrom_dt=15, coefficients=False):
     """
     Returns GP chromatic noise model :
 
@@ -395,6 +397,8 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
         Tspan from which to calculate frequencies for PSD-based GPs.
     :param components:
         Number of frequencies to use in 'diag' GPs.
+    :param chrom_dt:
+        Step size for linear_interpolation_basis in units of days.
     :param coefficients:
         Whether to keep coefficients of the GP.
 
@@ -433,7 +437,7 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
             log10_p = parameter.Uniform(-4, 1)
             log10_gam_p = parameter.Uniform(-3, 2)
 
-            chm_basis = gpk.linear_interp_basis_chromatic(dt=15*86400)
+            chm_basis = gpk.linear_interp_basis_chromatic(dt=chrom_dt*86400)
             chm_prior = gpk.periodic_kernel(log10_sigma=log10_sigma,
                                             log10_ell=log10_ell,
                                             log10_gam_p=log10_gam_p,
@@ -448,7 +452,7 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
             log10_p = parameter.Uniform(-4, 1)
             log10_gam_p = parameter.Uniform(-3, 2)
 
-            chm_basis = gpk.get_tf_quantization_matrix(df=200, dt=15*86400,
+            chm_basis = gpk.get_tf_quantization_matrix(df=200, dt=chrom_dt*86400,
                                                        dm=True, idx=idx)
             chm_prior = gpk.tf_kernel(log10_sigma=log10_sigma,
                                       log10_ell=log10_ell,
@@ -462,7 +466,7 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
             log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
 
-            chm_basis = gpk.linear_interp_basis_chromatic(dt=15*86400, idx=idx)
+            chm_basis = gpk.linear_interp_basis_chromatic(dt=chrom_dt*86400, idx=idx)
             chm_prior = gpk.se_dm_kernel(log10_sigma=log10_sigma,
                                          log10_ell=log10_ell)
         elif nondiag_kernel == 'sq_exp_rfband':
@@ -472,7 +476,7 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
             log10_ell2 = parameter.Uniform(2, 7)
             log10_alpha_wgt = parameter.Uniform(-4, 1)
 
-            dm_basis = gpk.get_tf_quantization_matrix(df=200, dt=15*86400,
+            dm_basis = gpk.get_tf_quantization_matrix(df=200, dt=chrom_dt*86400,
                                                       dm=True, idx=idx)
             dm_prior = gpk.sf_kernel(log10_sigma=log10_sigma,
                                      log10_ell=log10_ell,

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -168,7 +168,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                                        psd=chrom_psd, idx=chrom_idx,
                                        components=components, 
                                        nondiag_kernel=chrom_kernel,
-                                       coefficients=coefficients
+                                       coefficients=coefficients,
                                        chrom_dt=chrom_dt)
 
         if dm_expdip:

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -34,11 +34,11 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                           white_vary=True, components=30, upper_limit=False,
                           wideband=False, gamma_val=None, dm_var=False,
                           dm_type='gp', dmgp_kernel='diag', dm_psd='powerlaw',
-                          dm_nondiag_kernel='periodic', dmx_data=None,
-                          dm_annual=False, gamma_dm_val=None, chrom_gp=False,
-                          chrom_gp_kernel='nondiag',
+                          dm_nondiag_kernel='periodic', dm_dt=15,
+                          dmx_data=None, dm_annual=False, gamma_dm_val=None, 
+                          chrom_gp=False, chrom_gp_kernel='nondiag',
                           chrom_psd='powerlaw', chrom_idx=4,
-                          chrom_kernel='periodic',
+                          chrom_kernel='periodic', chrom_dt=15,
                           dm_expdip=False, dmexp_sign='negative',
                           dm_expdip_idx=2,
                           dm_expdip_tmin=None, dm_expdip_tmax=None,
@@ -76,6 +76,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
     :param dmgp_kernel: diagonal in frequency or non-diagonal
     :param dm_psd: power-spectral density of DM variations
     :param dm_nondiag_kernel: type of time-domain DM GP kernel
+    :param dm_dt: linear_interp_basis size in units of days
     :param dmx_data: supply the DMX data from par files
     :param dm_annual: include an annual DM signal
     :param gamma_dm_val: spectral index of power-law DM variations
@@ -86,6 +87,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
     :param chrom_idx: frequency scaling of chromatic noise
     :param chrom_kernel: Type of 'nondiag' time-domain chrom GP kernel to use
         ['periodic', 'sq_exp','periodic_rfband', 'sq_exp_rfband']
+    :param chrom_dt: linear_interp_basis size in units of days
     :param dm_expdip: inclue a DM exponential dip
     :param dmexp_sign: set the sign parameter for dip
     :param dm_expdip_idx: chromatic index of exponential dip
@@ -156,7 +158,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
             elif dmgp_kernel == 'nondiag':
                 s += dm_noise_block(gp_kernel=dmgp_kernel,
                                     nondiag_kernel=dm_nondiag_kernel,
-                                    coefficients=coefficients)
+                                    coefficients=coefficients, dm_dt=dm_dt)
         elif dm_type == 'dmx':
             s += chrom.dmx_signal(dmx_data=dmx_data[psr.name])
         if dm_annual:
@@ -164,9 +166,10 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
         if chrom_gp:
             s += chromatic_noise_block(gp_kernel=chrom_gp_kernel,
                                        psd=chrom_psd, idx=chrom_idx,
-                                       components=components,
+                                       components=components, 
                                        nondiag_kernel=chrom_kernel,
-                                       coefficients=coefficients)
+                                       coefficients=coefficients
+                                       chrom_dt=chrom_dt)
 
         if dm_expdip:
             if dm_expdip_tmin is None and dm_expdip_tmax is None:


### PR DESCRIPTION
Adding a dm_dt and a chrom_dt into single_pulsar model, which then allows user to set the linear_interp_basis dt for either dm_gp and chrom_gp